### PR TITLE
Update versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
  - Make list of valid certificate issuers configurable @instification
 
+### Changed
+
+ - Updated python version and some dependencies @instification
+
 
 ## 1.0.0 - 2025-07-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-alpine
+FROM python:3.11-alpine
 
 RUN apk update
 RUN apk add --no-cache gcc py-pip musl-dev libffi-dev openssl-dev linux-headers openssl libffi cargo

--- a/files/rancher.py
+++ b/files/rancher.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python3.9
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 # This python service is responsible for managing lets encrypt certificates.

--- a/files/rancher.py
+++ b/files/rancher.py
@@ -464,7 +464,7 @@ class RancherService:
     def port_open(self, host, port):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         result = sock.connect_ex((host, port))
-        return result is 0
+        return result == 0
 
     def check_hostnames_and_ports(self):
         done = False

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -4,3 +4,4 @@ certbot==1.15.0
 acme==1.15.0
 pyOpenSSL==23.1.1
 zope.event==5.0
+josepy<2.0

--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -3,3 +3,4 @@ requests==2.22.0
 certbot==1.15.0
 acme==1.15.0
 pyOpenSSL==23.1.1
+zope.event==5.0


### PR DESCRIPTION
Some minor fixes/upgrades to keep rancher-lets-encrypt working

For josepy issue see https://github.com/certbot/certbot/issues/10185

For some reason zope.event >5.1 causes a distributionnotfound exception.