### PR TITLE
Fix issuers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  
  - Add Makefile with basic build and push commands
+ - Make list of valid certificate issuers configurable @instification
+
+### Fixed
+
+ - Update list of valid certificate issuer codes @instification
 
 ### Changed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  
  - Make list of valid certificate issuers configurable @instification
+ - Add Makefile with basic build and push commands
+
+### Fixed
+
+ - Upgrade pyOpenSSL dependency to 23.1.1 @instification
+ - Update list of valid certificate issuer codes @instification
+
 
 
 ## 1.0.0 - 2025-07-08

--- a/files/rancher.py
+++ b/files/rancher.py
@@ -55,6 +55,10 @@ try:
     HOST_CHECK_LOOP_TIME = int(os.getenv('HOST_CHECK_LOOP_TIME', 10))
     # which port to use for LetsEncrypt verification. Defaults to 80.
     HOST_CHECK_PORT = int(os.getenv('HOST_CHECK_PORT', 80))
+    # See below link for list of active and backup cert types
+    # https://letsencrypt.org/certificates/
+    VALID_ISSUERS = os.getenv('VALID_ISSUERS', "E5,E6,R10,R11").split(',')
+ 
 
 except KeyError as e:
     print("ERROR: Could not find an Environment variable set.")
@@ -250,9 +254,11 @@ class RancherService:
                         print("INFO: Upgrading staging cert to production for {0}".format(server))
                         self.create_cert(server)
                         self.post_cert(server)
-                    # See below link for list of active and backup cert types
-                    # https://letsencrypt.org/certificates/
-                    elif not STAGING and ("R3" not in server_cert_issuer and "R4" not in server_cert_issuer and "E1" not in server_cert_issuer  and "E2" not in server_cert_issuer):
+                    
+                    elif not STAGING and not any(
+                        [issuer in server_cert_issuer for 
+                         issuer in VALID_ISSUERS]
+                    ):
                         # we have a self-signed certificate we should replace with a prod certificate.
                         # this should only happen once on initial rancher install.
                         print("INFO: Replacing self-signed certificate: {0}, "


### PR DESCRIPTION
This prevents recurring attempts to regenerate a certificate due to it not accepting the current intermediate chain as valid.

See https://github.com/tozny/rancher-lets-encrypt/pull/43 for a previous fix & discussion for long term fix.

The intermediate issuers are changeable and may change again. The latest list can be found at https://letsencrypt.org/certificates/

This PR adds a `VALID_ISSUERS` env var which defaults to `E5,E6,R10,R11` which at the time of writing were the currently valid. This will at least make it more convenient to change in future.

It seems like there might be a better way to figure out if a certificate is in fact self-signed but this is a quick and dirty fix for now